### PR TITLE
Fix encoding issue

### DIFF
--- a/artFileTool.xcodeproj/project.pbxproj
+++ b/artFileTool.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		FA1CCF3614F9587500A3889F /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1CCF3514F9587500A3889F /* Accelerate.framework */; };
 		FA93918313A28E890002047D /* Defines.m in Sources */ = {isa = PBXBuildFile; fileRef = FA93918213A28E890002047D /* Defines.m */; };
 		FA93918613A2908F0002047D /* encoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FA93918513A2908F0002047D /* encoder.m */; };
 		FAB92EB61481629600E5E8F8 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAB92EB51481629600E5E8F8 /* QuartzCore.framework */; };
@@ -32,7 +31,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FA1CCF3514F9587500A3889F /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
 		FA93918213A28E890002047D /* Defines.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Defines.m; sourceTree = "<group>"; };
 		FA93918513A2908F0002047D /* encoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = encoder.m; sourceTree = "<group>"; };
 		FA93918713A290960002047D /* encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoder.h; sourceTree = "<group>"; };
@@ -53,7 +51,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA1CCF3614F9587500A3889F /* Accelerate.framework in Frameworks */,
 				FAB92EB61481629600E5E8F8 /* QuartzCore.framework in Frameworks */,
 				FAE4830F13A288D600F0F1A8 /* Cocoa.framework in Frameworks */,
 				FAE482F513A2884800F0F1A8 /* Foundation.framework in Frameworks */,
@@ -66,6 +63,7 @@
 		FAE482E513A2884700F0F1A8 = {
 			isa = PBXGroup;
 			children = (
+				FAB92EB51481629600E5E8F8 /* QuartzCore.framework */,
 				FAE482F613A2884800F0F1A8 /* artFileTool */,
 				FAE482F313A2884800F0F1A8 /* Frameworks */,
 				FAE482F113A2884800F0F1A8 /* Products */,
@@ -83,8 +81,6 @@
 		FAE482F313A2884800F0F1A8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FA1CCF3514F9587500A3889F /* Accelerate.framework */,
-				FAB92EB51481629600E5E8F8 /* QuartzCore.framework */,
 				FAE4830E13A288D600F0F1A8 /* Cocoa.framework */,
 				FAE482F413A2884800F0F1A8 /* Foundation.framework */,
 			);

--- a/artFileTool/encoder.m
+++ b/artFileTool/encoder.m
@@ -7,14 +7,68 @@
 //
 
 #include "Defines.h"
-#include "encoder.h"
-
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
-#import <Accelerate/Accelerate.h>
 
-static int globalCounter;
 unsigned char* dataFromRep(NSBitmapImageRep *bitmapImageRep, BOOL unpremultiply, BOOL abgr);
+static int globalCounter;
+unsigned char* bytesFromData(NSData *data, uint16_t *w, uint16_t *h) {
+	if (!data) {
+		NSLog(@"no data");
+		return NULL;
+	}
+    // Create a bitmap from the source image data
+	
+    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:data];
+    NSInteger width = [imageRep pixelsWide];
+    NSInteger height = [imageRep pixelsHigh];
+    if (w != NULL) { *w = (uint16_t)width; }
+    if (h != NULL) { *h = (uint16_t)height; }
+    
+    unsigned char *bytes = [imageRep bitmapData];
+    for (NSUInteger y = 0; y < width * height * 4; y += 4) { // bgra little endian + alpha first
+		uint8_t a, r, g, b;
+		
+		if (imageRep.bitmapFormat & NSAlphaFirstBitmapFormat) {
+			a = bytes[y];
+			r = bytes[y+1];
+			g = bytes[y+2];
+			b = bytes[y+3];
+		} else {
+			r = bytes[y+0];
+			g = bytes[y+1];
+			b = bytes[y+2];
+			a = bytes[y+3];
+		}
+		
+		// unpremultiply alpha if there is any
+		if (a > 0) {
+			if (!(imageRep.bitmapFormat & NSAlphaNonpremultipliedBitmapFormat)) {
+				float factor = 255.0f/a;
+				b *= factor;
+				g *= factor;
+				r *= factor;
+			}
+		} else {
+			b = 0;
+			g = 0;
+			r = 0;
+		}
+		
+		if (!legacy) {
+			bytes[y]=b;
+			bytes[y+1]=g;
+			bytes[y+2]=r;
+			bytes[y+3]=a;
+		} else {
+			bytes[y]=a;
+			bytes[y+1]=r;
+			bytes[y+2]=g;
+			bytes[y+3]=b;
+		}
+	}
+    return bytes;
+}
 
 static unsigned char* bytesFromCGImage(CGImageRef image, uint16_t *w, uint16_t *h) {
 	if (!image)
@@ -24,66 +78,70 @@ static unsigned char* bytesFromCGImage(CGImageRef image, uint16_t *w, uint16_t *
 		
 	NSInteger width = CGImageGetWidth(image);
     NSInteger height = CGImageGetHeight(image);
+	NSInteger length = 0;
 	
     if (w != NULL) { *w = (uint16_t)width; }
     if (h != NULL) { *h = (uint16_t)height; }
-	
     
+	
 	CGDataProviderRef provider = CGImageGetDataProvider(image);
 	CFDataRef data = CGDataProviderCopyData(provider);
-	
-	UInt8* bytes = malloc(width * height * 4);
-	CFDataGetBytes(data, CFRangeMake(0, CFDataGetLength(data)), bytes);
+	length = CFDataGetLength(data);
+	UInt8* bytes = (UInt8*)CFDataGetBytePtr(data);
+
+	for (NSUInteger y = 0; y < width * height * 4; y += 4) { // bgra little endian + alpha first
+		uint8_t a, r, g, b;
+		
+		if ((alphaInfo & kCGImageAlphaFirst) == kCGImageAlphaFirst) {
+			a = bytes[y];
+			r = bytes[y+1];
+			g = bytes[y+2];
+			b = bytes[y+3];
+		} else {
+			r = bytes[y];
+			g = bytes[y+1];
+			b = bytes[y+2];
+			a = bytes[y+3];
+		}
+		
+		 // this distorts the image even more without unpremultiplying the alpha for some reason.
+		if (((alphaInfo & kCGImageAlphaPremultipliedFirst)==kCGImageAlphaPremultipliedFirst) || ((alphaInfo & kCGImageAlphaPremultipliedLast)==kCGImageAlphaPremultipliedLast)) {
+			float factor = 255.0f/(float)a;
+			r = r*factor;
+			g = g*factor;
+			b = b*factor;
+		}
+		if (a==0) {
+			r = 0;
+			g = 0;
+			b = 0;
+		}
+		
+		if (!legacy) {
+			bytes[y]=b;
+			bytes[y+1]=g;
+			bytes[y+2]=r;
+			bytes[y+3]=a;
+		} else {
+			bytes[y]=a;
+			bytes[y+1]=r;
+			bytes[y+2]=g;
+			bytes[y+3]=b;
+		} 
+	}
 	CFRelease(data);
-	
-	vImage_Buffer src;
-	src.data = (void*)bytes;
-	src.rowBytes = 4 * width;
-	src.width = width;
-	src.height = height;
-	
-	BOOL alphaFirst    = (alphaInfo == kCGImageAlphaFirst || alphaInfo == kCGImageAlphaPremultipliedFirst);
-	BOOL premultiplied = (alphaInfo == kCGImageAlphaPremultipliedFirst || alphaInfo == kCGImageAlphaPremultipliedLast);
-	BOOL little        = (CGImageGetBitmapInfo(image) == kCGBitmapByteOrder32Little);
-	
-	uint8_t permuteMap[4];
-	if (alphaFirst) {
-		if (little) {
-			// BGRA to BGRA
-			permuteMap[0] = 0;
-			permuteMap[1] = 1;
-			permuteMap[2] = 2;
-			permuteMap[3] = 3;
-		} else {
-			// ARGB to BGRA
-			permuteMap[0] = 3;
-			permuteMap[1] = 2;
-			permuteMap[2] = 1;
-			permuteMap[3] = 0;
-		}
-	} else {
-		if (little) {
-			// ABGR to BGRA
-			permuteMap[0] = 1;
-			permuteMap[1] = 2;
-			permuteMap[2] = 3;
-			permuteMap[3] = 0;
-		} else {
-			// RGBA to BGRA
-			permuteMap[0] = 2;
-			permuteMap[1] = 1;
-			permuteMap[2] = 0;
-			permuteMap[3] = 3;
-		}
-	}
-	
-	vImagePermuteChannels_ARGB8888(&src, &src, permuteMap, 0);
-	
-	if (premultiplied) {
-		vImageUnpremultiplyData_BGRA8888(&src, &src, 0);
-	}
-	
-	return src.data;
+	return bytes;
+}
+
+static unsigned char* bytesFromBitmapImageRep(NSBitmapImageRep *imageRep, uint16_t *w, uint16_t *h) {
+	CFDataRef data = (CFDataRef)[imageRep representationUsingType:NSPNGFileType properties:nil];
+	CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+	CGImageRef imageRef = CGImageCreateWithPNGDataProvider(provider, NULL, false, kCGRenderingIntentDefault);
+	unsigned char *bytes = bytesFromCGImage(imageRef, w, h);
+	CGImageRelease(imageRef);
+	CGDataProviderRelease(provider);
+	CFRelease(data);
+	return bytes;
 }
 
 static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
@@ -105,7 +163,6 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 		// write the file descriptor
 		[headerData replaceBytesInRange:NSMakeRange(header.file_descriptors_offset + sizeof(struct file_descriptor)*idx, sizeof(struct file_descriptor))
 							  withBytes:&fd];
-		
 		// find the path where out images are
 		NSString *currentFolderPath = folderPath;
 		for (int x = 0; x<sizeof(fd.tags); x++) {
@@ -135,9 +192,7 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 				uint16_t width;
 				uint16_t height;
 				
-				CGDataProviderRef provider = CGDataProviderCreateWithCFData((CFDataRef)tempData);
-				CGImageRef image = CGImageCreateWithPNGDataProvider(provider, NULL, false, kCGRenderingIntentDefault);
-				unsigned char *bytes = bytesFromCGImage(image, &width, &height);
+				unsigned char *bytes = bytesFromData(tempData, &width, &height);
 				
 				// set the goods
 				ah.subimage_heights[x] = height;
@@ -156,6 +211,7 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 			if (!tempData)
 				continue;
 			
+			
 			// split into pieces
 			int currentX;
 			int currentY = 0;
@@ -169,6 +225,8 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 				currentX=0;
 				
 				for (int y = 0; y<ah.art_columns; y++) {
+					
+					
 					uint32_t ci = x*ah.art_columns + y;
 					uint16_t width = ah.subimage_widths[ci];
 					uint16_t height = ah.subimage_heights[ci];
@@ -180,13 +238,13 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 						continue;
 					}
 					
+					
 					CGRect r = CGRectMake(currentX, currentY, width, height);
 					CGImageRef newRef = CGImageCreateWithImageInRect(totalImage, r);
 					
+					uint16_t fw, fh;
 					unsigned char * bytes = bytesFromCGImage(newRef,
-															 NULL, NULL);
-					
-					
+															 &fw, &fh);
 					
 					
 					currentX+=width;
@@ -207,6 +265,7 @@ static BOOL encodeImages(NSString *folderPath, NSString *destinationPath) {
 
 			}
 			CGImageRelease(totalImage);
+			
 		}
 		
 		printf("Encoded File Index : %i\n", idx);


### PR DESCRIPTION
- Fix encoding issue by not using CGImageCreateWithImageInRect+CGImageGetDataProvider+CGDataProviderCopyData (Quartz bug).
- Fix an issue where the CGImageAlphaInfo was treated as a bitfield instead of a plain enum.
